### PR TITLE
Set work directory for sops command

### DIFF
--- a/src/main/java/com/petriuk/sopsintellijplugin/SopsUtils.java
+++ b/src/main/java/com/petriuk/sopsintellijplugin/SopsUtils.java
@@ -29,7 +29,11 @@ public class SopsUtils {
   @SneakyThrows
   private static void execute(String actionParam, VirtualFile file) {
     var command = new GeneralCommandLine(SOPS_COMMAND);
-    command.addParameters(actionParam, "-i", file.getPath());
+    var path = file.getParent();
+    if (path != null) {
+      command.setWorkDirectory(path.getPath());
+    }
+    command.addParameters(actionParam, "-i", file.getName());
     command.setCharset(StandardCharsets.UTF_8);
 
     var processHandler = new OSProcessHandler(command);


### PR DESCRIPTION
Set work directory for sops command to honor sops configuration files in sub dirs.

        project
        ├── test
        │   ├── app1
        │   │   └── secret.yaml
        │   └── .sops.yaml