### PR TITLE
Make plugin forward compatible with new versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,7 @@ build/
 !**/src/test/**/build/
 
 ### IntelliJ IDEA ###
-.idea/modules.xml
-.idea/jarRepositories.xml
-.idea/compiler.xml
-.idea/libraries/
+.idea/
 *.iws
 *.iml
 *.ipr

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.petriuk"
-version = "1.1.3-alpha"
+version = "1.1.4-alpha"
 
 repositories {
     mavenCentral()
@@ -29,6 +29,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("145")
+        untilBuild.set("")
     }
 
     signPlugin {


### PR DESCRIPTION
Tested this with `IntelliJ IDEA 2023.1.4 (Ultimate Edition)`